### PR TITLE
bugfix: 0 read fasta raised an error instead of continue

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,20 @@
 # deblur changelog
 
+
+## Version 0.1.1-dev 
+### Features
+
+### Backward-incompatible changes [stable]
+
+### Performance enhancements
+
+### Bug fixes
+Fix total pipeline failure when a sample contains 1 read after dereplcation+singleton removal. Now issues a warning and continues [#75](https://github.com/biocore/deblur/issues/75)
+
+### Miscellaneous
+
 ## Version 0.1.0-dev 
+First release
 
 ### Features
 

--- a/deblur/test/test_workflow.py
+++ b/deblur/test/test_workflow.py
@@ -13,7 +13,6 @@ from os import listdir, remove
 from types import GeneratorType
 from os.path import join, isfile, abspath, dirname, splitext
 
-import skbio
 from skbio import DNA
 
 from biom import load_table
@@ -91,8 +90,14 @@ class workflowTests(TestCase):
         self.assertTrue(obs[0][1].startswith(first_few_nucs))
 
     def test_sequence_generator_invalid_format(self):
-        with self.assertRaises(skbio.io.FormatIdentificationWarning):
-            next(sequence_generator(join(self.test_data_dir, 'readme.txt')))
+        allres = []
+        input_fp = join(self.test_data_dir, 'readme.txt')
+        msg = "input file %s does not appear to be FASTA or FASTQ" % input_fp
+        with self.assertWarns(UserWarning) as W:
+            for res in sequence_generator(input_fp):
+                allres.append(res)
+        self.assertEqual(len(allres), 0)
+        self.assertEqual(str(W.warning), msg)
 
     def test_trim_seqs(self):
         seqs = [("seq1", "tagggcaagactccatggtatga"),

--- a/deblur/workflow.py
+++ b/deblur/workflow.py
@@ -69,8 +69,13 @@ def sequence_generator(input_fp):
         # http://scikit-bio.org/docs/latest/generated/skbio.io.format.fastq.html#format-parameters
         kw['variant'] = 'illumina1.8'
     else:
-        raise skbio.io.FormatIdentificationWarning("input_fp does not appear "
-                                                   "to be FASTA or FASTQ.")
+        # usually happens when the fasta file is empty
+        # so need to return no sequences (and warn)
+        logger = logging.getLogger(__name__)
+        msg = "input file %s does not appear to be FASTA or FASTQ" % input_fp
+        logger.warn(msg)
+        warnings.warn(msg, UserWarning)
+        return
 
     # some of the test code is using file paths, some is using StringIO.
     if isinstance(input_fp, io.TextIOBase):


### PR DESCRIPTION
following move to scikit-bio, when encountering a 0 read file (after msa), deblur raised an error instead of continuing with a warning.
fixed to write a warning and continue (so samples with 1 read will not stop the deblurring)