### PR TITLE
BUG/TST: verify an empty sequence file works gracefully

### DIFF
--- a/deblur/deblurring.py
+++ b/deblur/deblurring.py
@@ -43,7 +43,10 @@ def get_sequences(input_seqs):
         If all the sequences do not have the same length either aligned or
         unaligned.
     """
-    seqs = [Sequence(id, seq) for id, seq in input_seqs]
+    try:
+        seqs = [Sequence(id, seq) for id, seq in input_seqs]
+    except:
+        seqs = []
 
     if len(seqs) == 0:
         logger = logging.getLogger(__name__)

--- a/deblur/test/test_deblurring.py
+++ b/deblur/test/test_deblurring.py
@@ -8,7 +8,9 @@
 
 from unittest import TestCase, main
 from io import StringIO
+from os.path import join, dirname, abspath
 
+import skbio
 import numpy as np
 
 from deblur.sequence import Sequence
@@ -28,6 +30,7 @@ class DeblurringTests(TestCase):
                      ("151_5155;size=998;", "---gaggatgcgagatgcgtgg-----"),
                      ("151_527;size=964;", "---acggaggatgatgcgcggt-----"),
                      ("151_5777;size=305;", "---ggagtgcaagattccaggt-----")]
+        self.test_data_dir = join(dirname(abspath(__file__)), 'data')
 
     def test_get_default_error_profile(self):
         goodprofile = [1, 0.06, 0.02, 0.02, 0.01,
@@ -50,6 +53,11 @@ class DeblurringTests(TestCase):
 
         with self.assertRaises(ValueError):
             get_sequences(seqs)
+
+    def test_get_sequences_empty_file(self):
+        gen = skbio.read(join(self.test_data_dir, 'seqs_empty.fasta'),
+                         format='fasta')
+        self.assertEqual(get_sequences(gen), None)
 
     def test_get_sequences_error_empty(self):
         self.assertIsNone(get_sequences([]))


### PR DESCRIPTION
I was getting the following under a parallel run:

``` python
Traceback (most recent call last):
  File "/home/mcdonadt/miniconda3/envs/deblur/bin/deblur", line 621, in <module>
    deblur_cmds()
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 86, in augment_usage_errors
    yield
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/mcdonadt/miniconda3/envs/deblur/bin/deblur", line 592, in workflow
    parallel_deblur(input_file_list, sys.argv, ref_db_fp, jobs_to_start)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/deblur/parallel_deblur.py", line 131, in parallel_deblur
    es))
RuntimeError: stdout:
stderr: Traceback (most recent call last):
  File "/home/mcdonadt/miniconda3/envs/deblur/bin/deblur", line 621, in <module>
    deblur_cmds()
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/mcdonadt/miniconda3/envs/deblur/bin/deblur", line 584, in workflow
    negate=negate, threads_per_sample=threads_per_sample)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/deblur/workflow.py", line 688, in launch_workflow
    error_dist, indel_prob, indel_max)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/deblur/deblurring.py", line 111, in deblur
    seqs = get_sequences(input_seqs)
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/deblur/deblurring.py", line 46, in get_sequences
    seqs = [Sequence(id, seq) for id, seq in input_seqs]
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/deblur/deblurring.py", line 46, in <listcomp>
    seqs = [Sequence(id, seq) for id, seq in input_seqs]
  File "/home/mcdonadt/miniconda3/envs/deblur/lib/python3.5/site-packages/deblur/workflow.py", line 72, in sequence_generator
    raise skbio.io.FormatIdentificationWarning("input_fp does not appear "
skbio.io._warning.FormatIdentificationWarning: input_fp does not appear to be FASTA or FASTQ.

exit: 1
```

...seems like it was stemming from a warning raised by parsing an empty file. Unsure why a warning results in termination of the run but this resolves the problem
