### PR TITLE
Actually skip trim seqs

### DIFF
--- a/deblur/test/test_workflow.py
+++ b/deblur/test/test_workflow.py
@@ -139,7 +139,7 @@ class workflowTests(TestCase):
                 ("seq6", "ggatgcgagatgcgtggtgatt"),
                 ("seq7", "agggcgagattcctagtgga--")]
         with self.assertRaises(ValueError):
-            trim_seqs(seqs, -2)
+            list(trim_seqs(seqs, -2))
 
     def test_trim_seqs(self):
         seqs = [("seq1", "tagggcaagactccatggtatga"),

--- a/deblur/test/test_workflow.py
+++ b/deblur/test/test_workflow.py
@@ -119,6 +119,28 @@ class workflowTests(TestCase):
         self.assertEqual(len(allres), 0)
         self.assertEqual(str(W.warning), msg)
 
+    def test_trim_seqs_notrim(self):
+        seqs = [("seq1", "tagggcaagactccatggtatga"),
+                ("seq2", "cggaggcgagatgcgtggta"),
+                ("seq3", "tactagcaagattcctggtaaagga"),
+                ("seq4", "aggatgcgagatgcgtg"),
+                ("seq5", "gagtgcgagatgcgtggtgagg"),
+                ("seq6", "ggatgcgagatgcgtggtgatt"),
+                ("seq7", "agggcgagattcctagtgga--")]
+        obs = trim_seqs(seqs, -1)
+        self.assertEqual(list(obs), seqs)
+
+    def test_trim_seqs_notrim_outofbounds(self):
+        seqs = [("seq1", "tagggcaagactccatggtatga"),
+                ("seq2", "cggaggcgagatgcgtggta"),
+                ("seq3", "tactagcaagattcctggtaaagga"),
+                ("seq4", "aggatgcgagatgcgtg"),
+                ("seq5", "gagtgcgagatgcgtggtgagg"),
+                ("seq6", "ggatgcgagatgcgtggtgatt"),
+                ("seq7", "agggcgagattcctagtgga--")]
+        with self.assertRaises(ValueError):
+            trim_seqs(seqs, -2)
+
     def test_trim_seqs(self):
         seqs = [("seq1", "tagggcaagactccatggtatga"),
                 ("seq2", "cggaggcgagatgcgtggta"),

--- a/deblur/workflow.py
+++ b/deblur/workflow.py
@@ -108,7 +108,7 @@ def trim_seqs(input_seqs, trim_len):
     input_seqs : iterable of (str, str)
         The list of input sequences in (label, sequence) format
     trim_len : int
-        Sequence trimming length
+        Sequence trimming length. Specify a value of -1 to disable trimming.
 
     Returns
     -------
@@ -121,9 +121,16 @@ def trim_seqs(input_seqs, trim_len):
     okseqs = 0
     totseqs = 0
 
+    if trim_len < -1:
+        raise ValueError("Invalid trim_len: %d" % trim_len)
+
     for label, seq in input_seqs:
         totseqs += 1
-        if len(seq) >= trim_len:
+
+        if trim_len == -1:
+            okseqs += 1
+            yield label, seq
+        elif len(seq) >= trim_len:
             okseqs += 1
             yield label, seq[:trim_len]
 


### PR DESCRIPTION
The subcommand `trim` was not supporting the behavior of trim with a value of `-1`, and its use as such would have lead to a subtle bug as `seq[:-1] != seq`