### PR TITLE
BLD: setting vsearch req to >= 2.0.3, seems to work with 2.5.0 w/o issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 install:
   - conda create --yes -n env_name python=$PYTHON_VERSION pip numpy scipy nose flake8 h5py
   - source activate env_name
-  - conda install --yes -c bioconda VSEARCH=2.0.3 MAFFT=7.310 SortMeRNA=2.0
+  - conda install --yes -c bioconda "VSEARCH>=2.0.3" MAFFT=7.310 SortMeRNA=2.0
   - pip install coveralls
   - pip install --process-dependency-links .
 script:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,7 @@
 
 ### Performance enhancements
 * Updated MAFFT version requirement from 7.221 to 7.310.
-* Updatedd vsearch version requirement from 2.0.3 to >= 2.0.3
+* Updated vsearch version requirement from 2.0.3 to >= 2.0.3
 
 ### Bug fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # deblur changelog
 
-## Version 1.0.2
+## Version 1.0.3-dev
 
 ### Features
 
@@ -10,6 +10,11 @@
 
 ### Performance enhancements
 * Updated MAFFT version requirement from 7.221 to 7.310.
+* Updatedd vsearch version requirement from 2.0.3 to >= 2.0.3
+
+### Bug fixes
+
+## Version 1.0.2
 
 ### Bug fixes
 E-value thresholding removed in favor of a bitscore threshold which is scaled based on the length of the query sequence. This is to make each query sequence independent of each other on assessment against the positive filtering database. Please see [PR #146](https://github.com/biocore/deblur/pull/146) for further details.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ source activate deblurenv
 
 Install Deblur dependencies and Deblur itself:
 ```
-conda install -c bioconda -c biocore VSEARCH=2.0.3 MAFFT=7.310 biom-format SortMeRNA==2.0 deblur
+conda install -c bioconda -c biocore VSEARCH MAFFT=7.310 biom-format SortMeRNA==2.0 deblur
 ```
 
-N.B. Some dependencies are version restricted at the moment but for different reasons. SortMeRNA 2.1 has a different output format which Deblur is not compatible with yet. VSEARCH 2.0.3 yields slightly different results in testing than the latest version (at the time of release of Deblur 1.0.0). A review of the changelog did not reveal any remarkable notes (e.g., bugs) about the reasons for the differences. In testing, the differences affected <0.1% of the sOTUs. As a precaution, we are advising the use of these specific versions for consistency with the manuscript.
+N.B. Some dependencies are version restricted at the moment but for different reasons. SortMeRNA 2.1 has a different output format which Deblur is not compatible with yet. A review of the changelog did not reveal any remarkable notes (e.g., bugs) about the reasons for the differences. In testing, the differences affected <0.1% of the sOTUs. As a precaution, we are advising the use of these specific versions for consistency with the manuscript.
 
 Example usage
 =============


### PR DESCRIPTION
Changelog changes were because entries were going not under 1.0.3-dev