### PR TITLE
Update MacOS Matplotlib troubleshooting item

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,16 @@ Deblur runs on each sample independently. However, sometimes there is also addit
 
 Troubleshooting
 ===============
-- Mac users: if you get the following error:
 
-RuntimeError: Python is not installed as a framework. The Mac OS X backend will not be able to function correctly if Python is not installed as a framework. See the Python documentation for more information on installing Python as a framework on Mac OS X. Please either reinstall Python as a framework, or try one of the other backends. If you are Working with Matplotlib in a virtual enviroment see 'Working with Matplotlib in Virtual environments' in the Matplotlib FAQ
+- Mac users: if you get an error similar to the following:
 
-You can solve it by the following commands:
-```
-cd ~/.matplotlib
-echo "backend: TkAgg" >> ~/.matplotlib/matplotlibrc
-```
+  > RuntimeError: Python is not installed as a framework. The Mac OS X backend will not be able to function correctly if Python is not installed as a framework. _[...]_
+
+  You can solve it by the following commands:
+
+      cd ~/.matplotlib
+      echo "backend: TkAgg" >> ~/.matplotlib/matplotlibrc
+
 
 - "Too many open files" : This error indicates deblur is trying to split a single fasta/q file into per-sample files, and the OS does not allow so many open simultaneous open files. Current solution is to use the qiime1.9 command split_sequence_file_on_sample_ids.py or the equivalent qiime2 command to split the single fasta/q file into a directory of per sample fasta/q files and then run deblur with this directory as the input to deblur (--seqs-fp).
 

--- a/deblur/deblurring.py
+++ b/deblur/deblurring.py
@@ -45,7 +45,7 @@ def get_sequences(input_seqs):
     """
     try:
         seqs = [Sequence(id, seq) for id, seq in input_seqs]
-    except:
+    except Exception:
         seqs = []
 
     if len(seqs) == 0:
@@ -155,10 +155,10 @@ def deblur(input_seqs, mean_error=0.005,
 
             # We stop checking in the shortest sequence after removing trailing
             # indels. We need to do this in order to avoid double counting
-            # the insertions/deletions
-            l = min(seq_i_len, len(seq_j.sequence.rstrip('-')))
-            sub_seq_i = seq_i.np_sequence[:l]
-            sub_seq_j = seq_i.np_sequence[:l]
+            # the insertions/deletions.
+            length = min(seq_i_len, len(seq_j.sequence.rstrip('-')))
+            sub_seq_i = seq_i.np_sequence[:length]
+            sub_seq_j = seq_i.np_sequence[:length]
 
             mask = (sub_seq_i != sub_seq_j)
             # find all indels

--- a/deblur/parallel_deblur.py
+++ b/deblur/parallel_deblur.py
@@ -69,7 +69,7 @@ def run_functor(functor, *args, **kwargs):
     try:
         # This is where you do your actual work
         return functor(*args, **kwargs)
-    except:
+    except Exception:
         # Put all exception text into an exception and raise that
         raise Exception("".join(traceback.format_exception(*sys.exc_info())))
 

--- a/deblur/workflow.py
+++ b/deblur/workflow.py
@@ -39,7 +39,7 @@ def _get_fastq_variant(input_fp):
     for v in variants:
         try:
             next(skbio.read(input_fp, format='fastq', variant=v))
-        except:
+        except Exception:
             continue
         else:
             variant = v


### PR DESCRIPTION
In recent versions of Matplotlib, the [error message is slightly different](https://github.com/matplotlib/matplotlib/commit/cfb196037d5a2cc2d2721ba94eeb5a5f92645ab6) than was in the README. This updated version truncates the message to the first two sentences (which have not changed), and cleans up the formatting slightly.