### PR TITLE
always-use-pip-to-install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ before_install:
   # Update conda itself
   - conda update --yes conda
 install:
-  - conda create --yes -n env_name python=$PYTHON_VERSION pip numpy scipy nose flake8 h5py
-  - source activate env_name
+  - conda create --yes -n deblur python=$PYTHON_VERSION pip nose flake8 h5py
+  - source activate deblur
   - conda install --yes -c bioconda "VSEARCH>=2.0.3" MAFFT=7.310 SortMeRNA=2.0
-  - pip install coveralls
+  - pip install -U pip coveralls
   - pip install --process-dependency-links .
 script:
   - nosetests --with-doctest --with-coverage


### PR DESCRIPTION
@wasade and I noticed that we had random failures and turns out that the installations were getting messy based on how conda/pip resolved dependencies; thus, decided to just use pip so only one tool satisfies all dependencies, which seems to resolve the problem. 
