### PR TITLE
[BUG] Bug fix to use trim command

### DIFF
--- a/scripts/deblur
+++ b/scripts/deblur
@@ -137,7 +137,7 @@ def trim(seqs_fp, output_fp, trim_length, log_level, log_file):
     logger = logging.getLogger(__name__)
     logger.info('deblur deblur_seqs started on file %s' % seqs_fp)
     with open(output_fp, 'w') as out_f:
-        for label, seq in trim_seqs(sequence_generator(seqs_fp), trim_length):
+        for label, seq in trim_seqs(sequence_generator(seqs_fp), trim_length, 0):
             out_f.write(">%s\n%s\n" % (label, seq))
 
 


### PR DESCRIPTION
When I used `trim` command, I face an error as follows:

```
$ deblur trim -t 200 test.fasta.gz test_trim.fasta.gz
Traceback (most recent call last):
  File "INSTALL_DIR/bin/deblur", line 684, in <module>
    deblur_cmds()
  File "LIBRARY_DIR/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "LIBRARY_DIR/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "LIBRARY_DIR/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "LIBRARY_DIR/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "LIBRARY_DIR/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "INSTALL_DIR/bin/deblur", line 140, in trim
    for label, seq in trim_seqs(sequence_generator(seqs_fp), trim_length):
TypeError: trim_seqs() missing 1 required positional argument: 'left_trim_len'
```

I fixed this problem, adding zero to the function.