### PR TITLE
[BUG] Bug fix to use multiple-seq-alignment command

### DIFF
--- a/scripts/deblur
+++ b/scripts/deblur
@@ -302,9 +302,6 @@ def build_db_index(ref_fp, output_dir, log_level, log_file):
 @click.argument('seqs_fp', required=True,
                 type=click.Path(resolve_path=True, readable=True, exists=True,
                                 file_okay=True))
-@click.argument('output_fp', required=True,
-                type=click.Path(resolve_path=True, readable=True, exists=False,
-                                file_okay=True))
 @click.option('--threads-per-sample', '-a', required=False, type=int,
               default=1, show_default=True,
               help="Number of threads to use per sample (0 to use all)")
@@ -317,15 +314,12 @@ def build_db_index(ref_fp, output_dir, log_level, log_file):
                               exists=False, dir_okay=True),
               default='deblur.log',
               show_default=True, help="log file name")
-def multiple_seq_alignment(seqs_fp, output_fp, threads_per_sample,
+def multiple_seq_alignment(seqs_fp, threads_per_sample,
                            log_level, log_file):
     """Multiple sequence alignment"""
     start_log(level=log_level * 10, filename=log_file)
-    alignment = multiple_sequence_alignment(seqs_fp,
-                                            threads=threads_per_sample)
-
-    with open(output_fp, 'w') as f:
-        f.write(alignment.to_fasta())
+    multiple_sequence_alignment(seqs_fp,
+                                threads=threads_per_sample)
 
 
 # DE NOVO CHIMERA REMOVAL COMMAND


### PR DESCRIPTION
When I used deblur multiple-seq-alignment command, I face an error as follow:

```
$ deblur multiple-seq-alignment test.fasta.no_artifacts test.fasta.no_artifacts.ma
Traceback (most recent call last):
  File "INSTALL_DIR/bin/deblur", line 684, in <module>
    deblur_cmds()
  File "LIBRARY_DIR/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "LIBRARY_DIR/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "LIBRARY_DIR/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "LIBRARY_DIR/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "LIBRARY_DIR/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "INSTALL_DIR/bin/deblur", line 328, in multiple_seq_alignment
    f.write(alignment.to_fasta())
AttributeError: 'str' object has no attribute 'to_fasta'
```

This error happens because `multiple_seq_alignment` returns file path of the output directory and it is inserted into alignment. As t his variable is just a string type variable, it cannot use to_fasta method.

I fixed this problem removing the procedure to save the results into the specified path as mafft result has already been saved in seqs_fp + "msa" before finishing the function by system-called mafft. If it is required to use a specified output of multiple-seq-alignment command, please modify this additionally.