### PR TITLE
[BUG] Replace dash in fasta file output of debular command

### DIFF
--- a/scripts/deblur
+++ b/scripts/deblur
@@ -109,6 +109,7 @@ def deblur_seqs(seqs_fp, mean_error, error_dist, indel_prob,
     output_path = "%s.clean" % seqs_fp
     with open(output_path, 'w') as f:
         for s in seqs:
+            s.sequence = s.sequence.replace('-', '')
             f.write(s.to_fasta())
 
 


### PR DESCRIPTION
When I used remove-chimeras-denovo command after using deblur-seqs following the pipeline proposed in supplementary figure of deblur paper, the output is missing.
As debular.log only said the error happens, I directly used vsearch command described in the script and got a message that this file is not compatible with vsearch because of invalid character of "-".
This character is removed by workflow command, but it is not by deblur-seqs.
I added the line into the function to delete the character.