### PR TITLE
[DEV] Change output suffix of deblur_seqs command to align with build_biom_table

### DIFF
--- a/scripts/deblur
+++ b/scripts/deblur
@@ -106,7 +106,7 @@ def deblur_seqs(seqs_fp, mean_error, error_dist, indel_prob,
     seqs = deblur(sequence_generator(seqs_fp), mean_error, error_dist,
                   indel_prob, indel_max)
 
-    output_path = "%s.clean" % seqs_fp
+    output_path = "%s.deblur" % seqs_fp
     with open(output_path, 'w') as f:
         for s in seqs:
             f.write(s.to_fasta())


### PR DESCRIPTION
The suffix of the output file of deblur_seqs was ".clean", but it does not match with default `--file_type` parameter in build_biom_table (`.trim.derep.no_artifacts.msa.deblur.no_chimeras`).

I aligned the suffix with it. I checked git commit history, and referenced newer changes.