### PR TITLE
Fixed stand-alone version of multiple-seq-alignment

### DIFF
--- a/deblur/workflow.py
+++ b/deblur/workflow.py
@@ -492,7 +492,7 @@ def remove_artifacts_seqs(seqs_fp,
     return output_fp, okseqs, [blast_output_filename]
 
 
-def multiple_sequence_alignment(seqs_fp, threads=1):
+def multiple_sequence_alignment(seqs_fp, threads=1, output_fp=None):
     """Perform multiple sequence alignment on FASTA file using MAFFT.
 
     Parameters
@@ -517,7 +517,10 @@ def multiple_sequence_alignment(seqs_fp, threads=1):
     if stat(seqs_fp).st_size == 0:
         logger.warning('msa failed. file %s has no reads' % seqs_fp)
         return None
-    msa_fp = seqs_fp + '.msa'
+    if output_fp is None:
+        msa_fp = seqs_fp + '.msa'
+    else:
+        msa_fp = output_fp
     params = ['mafft', '--quiet', '--preservecase', '--parttree', '--auto',
               '--thread', str(threads), seqs_fp]
     sout, serr, res = _system_call(params, stdoutfilename=msa_fp)

--- a/scripts/deblur
+++ b/scripts/deblur
@@ -325,10 +325,8 @@ def multiple_seq_alignment(seqs_fp, output_fp, threads_per_sample,
     """Multiple sequence alignment"""
     start_log(level=log_level * 10, filename=log_file)
     alignment = multiple_sequence_alignment(seqs_fp,
-                                            threads=threads_per_sample)
-
-    with open(output_fp, 'w') as f:
-        f.write(alignment.to_fasta())
+                                            threads=threads_per_sample,
+                                            output_fp=output_fp)
 
 
 # DE NOVO CHIMERA REMOVAL COMMAND


### PR DESCRIPTION
Deblur throws the following error:

> AttributeError: 'str' object has no attribute 'to_fasta'

when running

> deblur multiple-seq-alignment

This error stems from the multiple_sequence_alignment returning string containing the path to created .msa file and not the Sequence object.
Two changes have been made to fix this issue:
1) optional output_fp argument has been added to multiple_sequence_alignment. To avoid breaking the existing code, if output_fp is not provided, then behavior does not change. If output_fp is provided, then msa_fp gets assigned to output_fp, resulting in the creation of multiple sequence alignment file in a path specified by output_fp.
2) In the multiple_seq_alignment function additional argument output_fp=output_fp is passed to multiple_sequence_alignment; since this already results in the creation of the requested msa file, the problematic code:
```
    with open(output_fp, 'w') as f:
        f.write(alignment.to_fasta())
```
can be removed.